### PR TITLE
TP - Fixing Footer Typo

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -7,7 +7,7 @@ export default function Footer({systemInfo}) {
         <p data-testid="footer-content">
           Organic is a project of{' '} 
           <a href="https://ucsb-cs156.github.io">CS156</a>, 
-          a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage
+          a course at UC Santa Barbara.  Its purpose: provide students and instructors with useful tools to manage
           Github organizations associated with programming and software engineering courses.
           The open source code is available on
           <> </>

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -8,7 +8,7 @@ describe("Footer tests", () => {
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 
-        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
+        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  Its purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
 
         
         const text = screen.getByTestId("footer-content");


### PR DESCRIPTION
In this PR, I fixed the typo in the footer and updated the footer tests as well. 
Correction made: changed "It's" to "Its"

Closes #4 

<img width="1414" alt="Screenshot 2024-02-25 at 21 45 08" src="https://github.com/ucsb-cs156-w24/proj-organic-w24-6pm-3/assets/92137214/791bfc51-3f1d-46aa-8d94-ce610036c06b"> (screenshot from localhost)
